### PR TITLE
Use seidel's algorithm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-var triangulate = require('delaunay-triangulate')
-var defaults = require('lodash.defaults')
+var seidel = require('seidel')
+var _ = require('lodash')
 
 module.exports = function (points, opts) {
   opts = opts || {}
-  defaults(opts, {top: 1, bottom: 0, closed: true})
+  _.defaults(opts, {top: 1, bottom: 0, closed: true})
 
   var n = points.length
   var positions
@@ -11,9 +11,26 @@ module.exports = function (points, opts) {
 
   (opts.top === opts.bottom) ? flat() : full()
 
+  function triangulate (points) {
+    return seidel([points]).map(function (t) {
+      var vertices = t.map(function (p) {
+        return _.findIndex(points, function (x) {
+          return Math.abs(x[0] - p.x) < 0.0000001 & Math.abs(x[1] - p.y) < 0.0000001
+        })
+      })
+      var c0 = [t[1].x - t[0].x, t[1].y - t[0].y]
+      var c1 = [t[2].x - t[0].x, t[2].y - t[0].y]
+      var cross = (c0[0] * c1[1]) - (c0[1] * c1[0])
+      if (cross < 0) {
+        vertices = [vertices[0], vertices[2], vertices[1]]
+      }
+      return vertices
+    })
+  }
+
   function flat () {
     positions = points.map(function (p) { return [p[0], p[1], opts.top] })
-    cells = triangulate(points).map(function (p) { return p.sort() })
+    cells = triangulate(points)
   }
 
   function full () {
@@ -33,7 +50,7 @@ module.exports = function (points, opts) {
     }
 
     if (opts.closed) {
-      var top = triangulate(points).map(function (p) { return p.sort() })
+      var top = triangulate(points)
       var bottom = top.map(function (p) { return p.map(function (v) { return v + n }) })
       bottom = bottom.map(function (p) { return [p[0], p[2], p[1]] })
       cells = cells.concat(top).concat(bottom)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "turn a 2d shape into a 3d mesh with extrusion",
   "main": "index.js",
   "scripts": {
-    "test": "standard & npm run tape",
+    "test": "npm run tape & standard",
     "tape": "tape test.js | tap-spec",
     "start": "budo example.js:bundle.js --live --open",
     "demo": "budo demo.js:bundle.js --live"
@@ -36,8 +36,9 @@
   },
   "homepage": "https://github.com/freeman-lab/extrude#readme",
   "dependencies": {
-    "delaunay-triangulate": "^1.1.6",
-    "lodash.defaults": "^3.1.2"
+    "gl-vignette-background": "^2.0.1",
+    "lodash": "^4.0.0",
+    "seidel": "^0.2.4"
   },
   "devDependencies": {
     "budo": "^7.1.0",

--- a/shaders/demo.frag
+++ b/shaders/demo.frag
@@ -3,29 +3,25 @@ precision mediump float;
 varying vec3 vposition;
 varying vec3 vnormal;
 
-uniform vec3 light1;
-uniform vec3 light2;
+uniform vec3 color1;
+uniform vec3 color2;
 uniform vec3 eye;
 
 #pragma glslify: orenn = require('glsl-diffuse-oren-nayar')
 
 void main() {
 	vec3 viewdiff = eye - vposition;
-	vec3 lightdir1 = light1 - vposition;
-	vec3 lightdir2 = light2 - vposition;
-	vec3 lightdir3 = vec3(0.0)
+	vec3 lightdir1 = (eye - vposition) + vec3(-2.0, 0.0, 1.0);
+	vec3 lightdir2 = (eye - vposition) + vec3(1.0, 0.0, 1.0);
 
 	float diff1 = orenn(normalize(lightdir1), normalize(viewdiff), vnormal, 0.9, 1.0);
 	float diff2 = orenn(normalize(lightdir2), normalize(viewdiff), vnormal, 0.9, 1.0);
-	float diff3 = orenn(normalize(lightdir3), normalize(viewdiff), vnormal, 0.9, 1.0);
 
-	vec3 lcol1 = vec3(0.5, 1.0, 0.8);
-	vec3 lcol2 = vec3(1.0, 0.2, 0.5);
-	vec3 lcol3 = vec3(1.0, 0.2, 0.5);
+	vec3 lcol1 = color1;
+	vec3 lcol2 = color2;
 
 	vec3 material = vec3(1.0, 1.0, 1.0);
 
-	vec3 result = lcol1 * vec3(material * diff1) + lcol2 * vec3(material * diff2) + lcol3 * vec3(material * diff3);
-
+	vec3 result = lcol1 * vec3(material * diff1) + lcol2 * vec3(material * diff2);
  	gl_FragColor = vec4(result, 1.0);
 }

--- a/shapes/circle.js
+++ b/shapes/circle.js
@@ -1,0 +1,13 @@
+var range = require('lodash.range')
+var line = range(0, Math.PI * 2, Math.PI * 2 / 30)
+
+var points = line.map(function (t) {
+  var x = Math.sin(t)
+  var y = Math.cos(t)
+  return [x, y]
+})
+
+module.exports = {
+  points: points.reverse(),
+  colors: [[0.9, 0.8, 0.1], [0.8, 0.6, 0.2]]
+}

--- a/shapes/heart.js
+++ b/shapes/heart.js
@@ -1,0 +1,13 @@
+var range = require('lodash.range')
+var line = range(0, Math.PI * 2, Math.PI * 2 / 50)
+
+var points = line.map(function (t) {
+  var x = 16 * Math.pow(Math.sin(t), 3)
+  var y = 13 * Math.cos(t) - 5 * Math.cos(2 * t) - 2 * Math.cos(3 * t) - Math.cos(4 * t)
+  return [x / 13, y / 13]
+})
+
+module.exports = {
+  points: points.reverse(),
+  colors: [[0.9, 0.3, 0.1], [1.0, 0.2, 0.3]]
+}

--- a/shapes/hexagon.js
+++ b/shapes/hexagon.js
@@ -1,0 +1,13 @@
+var points = []
+
+for (var i = 0; i < 6; i++) {
+  points.push([
+    Math.cos(i * 2 * Math.PI / 6),
+    Math.sin(i * 2 * Math.PI / 6)
+  ])
+}
+
+module.exports = {
+  points: points,
+  colors: [[0.5, 0.9, 0.1], [0.3, 1.0, 0.5]]
+}

--- a/shapes/square.js
+++ b/shapes/square.js
@@ -1,0 +1,7 @@
+var d = 0.75
+var points = [[-d, -d], [d, -d], [d, d], [-d, d]]
+
+module.exports = {
+  points: points,
+  colors: [[0.7, 0.2, 0.8], [0.6, 0.4, 0.9]]
+}

--- a/shapes/triangle.js
+++ b/shapes/triangle.js
@@ -1,0 +1,7 @@
+var d = 1
+var points = [[-d, -0.4 * d * Math.sqrt(3)], [d, -0.4 * d * Math.sqrt(3)], [0, 0.6 * d * Math.sqrt(3)]]
+
+module.exports = {
+  points: points,
+  colors: [[0.1, 0.6, 0.9], [0.2, 0.5, 0.7]]
+}

--- a/test.js
+++ b/test.js
@@ -14,10 +14,10 @@ test('cube: cells', function (t) {
     [3, 2, 7],
     [7, 4, 3],
     [0, 3, 4],
-    [1, 2, 3],
     [0, 1, 3],
-    [5, 7, 6],
-    [4, 7, 5]
+    [3, 1, 2],
+    [4, 7, 5],
+    [7, 6, 5]
   ]
   allclose(t)(complex.cells, truth)
   t.end()
@@ -90,8 +90,8 @@ test('cube: cells (flat)', function (t) {
   var opts = {top: 0, bottom: 0}
   var complex = extrude([[-1, -1], [1, -1], [1, 1], [-1, 1]], opts)
   var truth = [
-    [1, 2, 3],
-    [0, 1, 3]
+    [0, 1, 3],
+    [3, 1, 2]
   ]
   allclose(t)(complex.cells, truth)
   t.end()


### PR DESCRIPTION
This PR uses Seidel's algorithm via [this implementation on npm](https://www.npmjs.com/package/seidel) to enable support for non-convex shapes. Also added a non-convex shape example to the demo, and cleaned up the demo and tests.
